### PR TITLE
feat: enhance chat history retrieval for agents and swarms

### DIFF
--- a/swarmzero/agent.py
+++ b/swarmzero/agent.py
@@ -307,7 +307,7 @@ class Agent:
             media_type="text/event-stream",
         )
 
-    async def chat_history(self, user_id="default_user", session_id="default_chat") -> dict[str, list]:
+    async def chat_history(self, user_id="", session_id="") -> dict[str, list]:
         await self._ensure_utilities_loaded()
         db_manager = self.sdk_context.get_utility("db_manager")
 
@@ -315,7 +315,10 @@ class Agent:
             self.__agent, user_id=user_id, session_id=session_id, agent_id=self.id, swarm_id=self.swarm_id
         )
 
-        chats = await chat_manager.get_all_chats_for_user(db_manager)
+        if session_id:
+            chats = await chat_manager.get_messages(db_manager)
+        else:
+            chats = await chat_manager.get_all_chats_for_user(db_manager)
         return chats
 
     def query(self, *args, **kwargs):

--- a/swarmzero/swarm.py
+++ b/swarmzero/swarm.py
@@ -214,13 +214,16 @@ class Swarm:
             media_type="text/event-stream",
         )
 
-    async def chat_history(self, user_id="default_user", session_id="default_chat") -> dict[str, list]:
+    async def chat_history(self, user_id="", session_id="") -> dict[str, list]:
         await self._ensure_utilities_loaded()
         db_manager = self.sdk_context.get_utility("db_manager")
 
         chat_manager = ChatManager(self.__swarm, user_id=user_id, session_id=session_id, swarm_id=self.id)
 
-        chats = await chat_manager.get_all_chats_for_user(db_manager)
+        if session_id:
+            chats = await chat_manager.get_messages(db_manager)
+        else:
+            chats = await chat_manager.get_all_chats_for_user(db_manager)
         return chats
 
     def _format_tool_name(self, name: str) -> str:


### PR DESCRIPTION
- Updated `chat_history` method in Agent and Swarm classes to support flexible chat retrieval
- Added conditional logic to use `get_messages` when a session_id is provided
- Fallback to `get_all_chats_for_user` when no session_id is specified
- Updated corresponding tests to verify new chat history retrieval behavior

This change improves the flexibility of chat history retrieval across agents and swarms.