### PR TITLE
refactor: remove type hint from chat_history method return type

### DIFF
--- a/swarmzero/agent.py
+++ b/swarmzero/agent.py
@@ -307,7 +307,7 @@ class Agent:
             media_type="text/event-stream",
         )
 
-    async def chat_history(self, user_id="", session_id="") -> dict[str, list]:
+    async def chat_history(self, user_id="", session_id=""):
         await self._ensure_utilities_loaded()
         db_manager = self.sdk_context.get_utility("db_manager")
 

--- a/swarmzero/swarm.py
+++ b/swarmzero/swarm.py
@@ -214,7 +214,7 @@ class Swarm:
             media_type="text/event-stream",
         )
 
-    async def chat_history(self, user_id="", session_id="") -> dict[str, list]:
+    async def chat_history(self, user_id="", session_id=""):
         await self._ensure_utilities_loaded()
         db_manager = self.sdk_context.get_utility("db_manager")
 


### PR DESCRIPTION
Removed the explicit return type annotation `-> dict[str, list]` from the `chat_history` method in both `Agent` and `Swarm` classes to improve method flexibility