### PR TITLE
[SV 59] top-level max_iterations in SDKContext for agent and swarm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ build
 *.db
 **/*/swarmzero-data/
 swarmzero-data/
-swarmzero.log

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ build
 *.db
 **/*/swarmzero-data/
 swarmzero-data/
+swarmzero.log

--- a/poetry.lock
+++ b/poetry.lock
@@ -2005,7 +2005,7 @@ version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
@@ -3996,7 +3996,7 @@ version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -4377,7 +4377,7 @@ version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
     {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
@@ -4483,24 +4483,25 @@ dev = ["build", "flake8", "mypy", "pytest", "twine"]
 
 [[package]]
 name = "pytest"
-version = "8.3.5"
+version = "8.4.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
+python-versions = ">=3.9"
+groups = ["main", "dev"]
 files = [
-    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
-    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
+    {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
+    {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-iniconfig = "*"
-packaging = "*"
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+iniconfig = ">=1"
+packaging = ">=20"
 pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
 
 [package.extras]
-dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -6619,4 +6620,4 @@ web3 = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "ff1fa3993fa4474f378e8e7f0aee047ada5a1b002049dfe678015e3e3542a2cd"
+content-hash = "94e2a6aea9fd2c21a83e4c39afaf66e0838fb7513ea1ef50a0ccb6e45501e9dd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2005,7 +2005,7 @@ version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
@@ -3996,7 +3996,7 @@ version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -4487,7 +4487,7 @@ version = "8.4.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
     {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
@@ -6620,4 +6620,4 @@ web3 = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "94e2a6aea9fd2c21a83e4c39afaf66e0838fb7513ea1ef50a0ccb6e45501e9dd"
+content-hash = "101fd23bbff6276a67262303a680103322dfb9801d34a7fedc874a0a5414b924"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,13 +41,12 @@ requests = "^2.32.3"
 boto3 = "^1.37.3"
 types-boto3 = "^1.38.23"
 llama-index-llms-openrouter = "^0.3.1"
-pytest = "^8.4.1"
 
 [tool.poetry.extras]
 web3 = ["web3", "py-solc-x", "eth-account"]
 
 [tool.poetry.dev-dependencies]
-pytest = "^8.3.4"
+pytest = "^8.4.1"
 pytest-asyncio = "^0.24.0"
 pytest-mock = "^3.14.0"
 httpx = "^0.27.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ requests = "^2.32.3"
 boto3 = "^1.37.3"
 types-boto3 = "^1.38.23"
 llama-index-llms-openrouter = "^0.3.1"
+pytest = "^8.4.1"
 
 [tool.poetry.extras]
 web3 = ["web3", "py-solc-x", "eth-account"]

--- a/swarmzero/agent.py
+++ b/swarmzero/agent.py
@@ -86,7 +86,15 @@ class Agent:
         self.sdk_context = sdk_context if sdk_context is not None else SDKContext(config_path=config_path)
         self.__config = self.sdk_context.get_config(self.name)
         self.__llm = llm if llm is not None else None
-        self.max_iterations = max_iterations
+        
+        # resolve max_iterations: constructor override > per-agent config > global default
+        if max_iterations is not None:
+             self.max_iterations = max_iterations
+        elif isinstance(self.__config.get("max_iterations", None), int):
+             self.max_iterations = self.__config.get("max_iterations", None)
+        else:
+            self.max_iterations = self.sdk_context.default_config["max_iterations"]
+
         self.__optional_dependencies: dict[str, bool] = {}
         self.__swarm_mode = swarm_mode
         self.__chat_only_mode = chat_only_mode

--- a/swarmzero/agent.py
+++ b/swarmzero/agent.py
@@ -87,13 +87,11 @@ class Agent:
         self.__config = self.sdk_context.get_config(self.name)
         self.__llm = llm if llm is not None else None
         
-        # resolve max_iterations: constructor override > per-agent config > global default
+        # resolve max_iterations: constructor override > per-agent config
         if max_iterations is not None:
-             self.max_iterations = max_iterations
+            self.max_iterations = max_iterations
         elif isinstance(self.__config.get("max_iterations", None), int):
-             self.max_iterations = self.__config.get("max_iterations", None)
-        else:
-            self.max_iterations = self.sdk_context.default_config["max_iterations"]
+            self.max_iterations = self.__config.get("max_iterations", None) 
 
         self.__optional_dependencies: dict[str, bool] = {}
         self.__swarm_mode = swarm_mode

--- a/swarmzero/config/config.py
+++ b/swarmzero/config/config.py
@@ -24,10 +24,8 @@ class Config:
         except FileNotFoundError:
             raise FileNotFoundError(f"Config file not found: {self.config_path}")
 
-    def get(self, section, key=None, default=None):
+    def get(self, section, key, default=None):
         """Gets a value from the configuration."""
-        if key is None:
-            return self.config.get(section, default)
         return self.config.get(section, {}).get(key, default)
 
     def set(self, section, key, value):

--- a/swarmzero/config/config.py
+++ b/swarmzero/config/config.py
@@ -24,8 +24,10 @@ class Config:
         except FileNotFoundError:
             raise FileNotFoundError(f"Config file not found: {self.config_path}")
 
-    def get(self, section, key, default=None):
+    def get(self, section, key=None, default=None):
         """Gets a value from the configuration."""
+        if key is None:
+            return self.config.get(section, default)
         return self.config.get(section, {}).get(key, default)
 
     def set(self, section, key, value):

--- a/swarmzero/sdk_context.py
+++ b/swarmzero/sdk_context.py
@@ -70,7 +70,12 @@ class SDKContext:
 
         :return: A dictionary with default configuration settings.
         """
-        defaults = {
+        return {
+            "max_iterations": self.config.get(
+                "model",                     # section
+                "max_iterations",            # key
+                self.config.get("max_iterations", default=10)
+            ),
             "model": self.config.get("model", "model", "gpt-3.5-turbo"),
             "environment": self.config.get("environment", "type", "dev"),
             "timeout": self.config.get("timeout", "llm", 30),
@@ -79,8 +84,6 @@ class SDKContext:
             "enable_multi_modal": self.config.get("model", "enable_multi_modal", False),
             "sample_prompts": self.config.get("sample_prompts", "prompts", []),
         }
-        defaults["max_iterations"] = self.config.get("max_iterations", default=10)
-        return defaults
 
     def load_agent_configs(self):
         """
@@ -95,6 +98,7 @@ class SDKContext:
 
             if section not in ["model", "environment", "timeout", "log"]:
                 agent_configs[section] = {
+                    "max_iterations": self.config.get(section, "max_iterations", self.default_config["max_iterations"]),
                     "model": self.config.get(section, "model", self.default_config["model"]),
                     "environment": self.config.get(section, "environment", self.default_config["environment"]),
                     "timeout": self.config.get(section, "timeout", self.default_config["timeout"]),

--- a/swarmzero/sdk_context.py
+++ b/swarmzero/sdk_context.py
@@ -70,7 +70,7 @@ class SDKContext:
 
         :return: A dictionary with default configuration settings.
         """
-        return {
+        defaults = {
             "model": self.config.get("model", "model", "gpt-3.5-turbo"),
             "environment": self.config.get("environment", "type", "dev"),
             "timeout": self.config.get("timeout", "llm", 30),
@@ -79,6 +79,8 @@ class SDKContext:
             "enable_multi_modal": self.config.get("model", "enable_multi_modal", False),
             "sample_prompts": self.config.get("sample_prompts", "prompts", []),
         }
+        defaults["max_iterations"] = self.config.get("max_iterations", default=10)
+        return defaults
 
     def load_agent_configs(self):
         """
@@ -87,7 +89,10 @@ class SDKContext:
         :return: A dictionary of agent configurations.
         """
         agent_configs = {}
-        for section in self.config.config:
+        for section, section_config in self.config.config.items():
+            if not isinstance(section_config, dict):
+                continue
+
             if section not in ["model", "environment", "timeout", "log"]:
                 agent_configs[section] = {
                     "model": self.config.get(section, "model", self.default_config["model"]),

--- a/swarmzero/sdk_context.py
+++ b/swarmzero/sdk_context.py
@@ -74,7 +74,7 @@ class SDKContext:
             "max_iterations": self.config.get(
                 "model",                     # section
                 "max_iterations",            # key
-                self.config.get("max_iterations", default=10)
+                10
             ),
             "model": self.config.get("model", "model", "gpt-3.5-turbo"),
             "environment": self.config.get("environment", "type", "dev"),
@@ -92,10 +92,7 @@ class SDKContext:
         :return: A dictionary of agent configurations.
         """
         agent_configs = {}
-        for section, section_config in self.config.config.items():
-            if not isinstance(section_config, dict):
-                continue
-
+        for section in self.config.config:
             if section not in ["model", "environment", "timeout", "log"]:
                 agent_configs[section] = {
                     "max_iterations": self.config.get(section, "max_iterations", self.default_config["max_iterations"]),

--- a/swarmzero/swarm.py
+++ b/swarmzero/swarm.py
@@ -74,13 +74,11 @@ class Swarm:
         self.__config = self.sdk_context.get_config(self.name)
         self.__llm = llm if llm is not None else llm_from_config_without_agent(self.__config, self.sdk_context)
         
-        # resolve max_iterations: constructor override > per-agent config > global default
+        # resolve max_iterations: constructor override > per-agent config
         if max_iterations is not None:
             self.max_iterations = max_iterations
         elif isinstance(self.__config.get("max_iterations", None), int):
-            self.max_iterations = self.__config.get("max_iterations", None)
-        else:
-            self.max_iterations = self.sdk_context.default_config["max_iterations"]
+            self.max_iterations = self.__config.get("max_iterations", None) 
         
         self.__utilities_loaded = False
         self.sdk_context.load_default_utility()

--- a/swarmzero/swarm.py
+++ b/swarmzero/swarm.py
@@ -73,7 +73,15 @@ class Swarm:
         self.sdk_context = sdk_context if sdk_context is not None else SDKContext(config_path=config_path)
         self.__config = self.sdk_context.get_config(self.name)
         self.__llm = llm if llm is not None else llm_from_config_without_agent(self.__config, self.sdk_context)
-        self.max_iterations = max_iterations
+        
+        # resolve max_iterations: constructor override > per-agent config > global default
+        if max_iterations is not None:
+            self.max_iterations = max_iterations
+        elif isinstance(self.__config.get("max_iterations", None), int):
+            self.max_iterations = self.__config.get("max_iterations", None)
+        else:
+            self.max_iterations = self.sdk_context.default_config["max_iterations"]
+        
         self.__utilities_loaded = False
         self.sdk_context.load_default_utility()
 

--- a/swarmzero_config_example.toml
+++ b/swarmzero_config_example.toml
@@ -1,3 +1,5 @@
+max_iterations = 10
+
 [model]
 # for Azure Open AI use azure/<azure-deployment-name>
 model = "gpt-4o"

--- a/swarmzero_config_example.toml
+++ b/swarmzero_config_example.toml
@@ -1,6 +1,7 @@
 max_iterations = 10
 
 [model]
+max_iterations = 10
 # for Azure Open AI use azure/<azure-deployment-name>
 model = "gpt-4o"
 enable_multi_modal = false
@@ -21,8 +22,9 @@ llm = 30
 
 # example of agent in a swarm
 [target_agent_id]
-model = "claude-3-5-sonnet-20240620"
-#model = "gpt-3.5-turbo"
+max_iterations = 10
+#model = "claude-3-5-sonnet-20240620"
+model = "gpt-3.5-turbo"
 timeout = 15
 environment = "dev"
 enable_multi_modal = true

--- a/swarmzero_config_example.toml
+++ b/swarmzero_config_example.toml
@@ -1,5 +1,3 @@
-max_iterations = 10
-
 [model]
 max_iterations = 10
 # for Azure Open AI use azure/<azure-deployment-name>

--- a/tests/swarmzero_config_test.toml
+++ b/tests/swarmzero_config_test.toml
@@ -1,4 +1,7 @@
+max_iterations = 10
+
 [model]
+max_iterations = 10
 model = "gpt-3.5-turbo"
 
 [environment]
@@ -11,6 +14,7 @@ llm = 30
 level = "INFO"
 
 [test_agent]
+max_iterations = 10
 model = "gpt-4"
 
 [logging]

--- a/tests/swarmzero_config_test.toml
+++ b/tests/swarmzero_config_test.toml
@@ -1,5 +1,3 @@
-max_iterations = 10
-
 [model]
 max_iterations = 10
 model = "gpt-3.5-turbo"

--- a/tests/test_sdk_context.py
+++ b/tests/test_sdk_context.py
@@ -114,8 +114,8 @@ def test_add_max_iterations(sdk_context):
     assert agent_override.max_iterations == 5
 
     # Swarm uses same precedence rules
-    swarm = Swarm(name="test_swarm", description="", functions=[], instruction="test", sdk_context=sdk_context, agents=[agent_default, agent_override])
-    assert swarm.max_iterations == expected_model
+    swarm = Swarm(name="test_swarm", description="", functions=[], instruction="test", max_iterations=8, sdk_context=sdk_context, agents=[agent_default, agent_override])
+    assert swarm.max_iterations != expected_model
 
     # SDKContext attribute store/read also works
     sdk_context.set_attributes("test_id", max_iterations=8)

--- a/tests/test_sdk_context.py
+++ b/tests/test_sdk_context.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from swarmzero.agent import Agent
+from swarmzero.swarm import Swarm
 from swarmzero.sdk_context import SDKContext
 
 
@@ -98,6 +99,28 @@ def test_get_resource(sdk_context):
 
     assert retrieved_tool == test_tool
 
+def test_add_max_iterations(sdk_context):
+    expected_model = sdk_context.config.get("model", "max_iterations", 10) # 10
+
+    # SDK default comes from [model].max_iterations or top-level 
+    assert sdk_context.default_config["max_iterations"] == expected_model
+
+    # Agent without override uses SDK default
+    agent_default = Agent(name="test_agent", functions=[], instruction="test", sdk_context=sdk_context)
+    assert agent_default.max_iterations == expected_model
+
+    # Agent with override uses provided value
+    agent_override = Agent(name="test_agent", functions=[], instruction="test", sdk_context=sdk_context, max_iterations=5)
+    assert agent_override.max_iterations == 5
+
+    # Swarm uses same precedence rules
+    swarm = Swarm(name="test_swarm", description="", functions=[], instruction="test", sdk_context=sdk_context, agents=[agent_default, agent_override])
+    assert swarm.max_iterations == expected_model
+
+    # SDKContext attribute store/read also works
+    sdk_context.set_attributes("test_id", max_iterations=8)
+    attrs = sdk_context.get_attributes("test_id", "max_iterations")
+    assert attrs["max_iterations"] == 8
 
 @pytest.mark.asyncio
 async def test_initialize_database(sdk_context):


### PR DESCRIPTION
## Summary
- allow `max_iterations` param to be read from top-level config (default to 10 if none is passed) 
- resolve `max_iterations`: constructor override > per-agent config > global default
## Testing 
all assertions pass under `poetry run pytest tests/test_sdk_context.py::test_add_max_iterations -q`