### PR TITLE
Fix local file retrieval path

### DIFF
--- a/swarmzero/filestore/filestore.py
+++ b/swarmzero/filestore/filestore.py
@@ -184,7 +184,11 @@ class FileStore:
                 logger.error(f"Failed to retrieve file from S3: {e}")
                 raise IOError(f"Error retrieving file {filename} from S3")
         else:
-            file_location = os.path.join(filename)
+            # When storing files locally, ensure we look in the configured
+            # base directory.  Previously this function used
+            # ``os.path.join(filename)`` which simply returned ``filename``
+            # without the base directory and caused lookups to fail.
+            file_location = os.path.join(self.base_dir, filename)
             if not os.path.exists(file_location):
                 logger.warning(f"File {filename} does not exist locally.")
                 return None

--- a/tests/filestore/test_filestore.py
+++ b/tests/filestore/test_filestore.py
@@ -1,11 +1,12 @@
 import os
 import shutil
+import base64
 from io import BytesIO
 
 import pytest
 from fastapi import UploadFile
 
-from swarmzero.filestore import FileStore
+from swarmzero.filestore.filestore import FileStore
 
 
 @pytest.fixture(scope="module")
@@ -58,3 +59,15 @@ def test_rename_file(file_store):
     assert file_store.rename_file(old_filename, new_filename)
     assert not os.path.exists(old_file_path)
     assert os.path.exists(new_file_path)
+
+
+def test_get_file(file_store):
+    filename = "get_file.txt"
+    content = b"hello"
+    # create file manually
+    file_path = os.path.join(file_store.base_dir, filename)
+    with open(file_path, "wb") as f:
+        f.write(content)
+
+    encoded = file_store.get_file(filename)
+    assert encoded == base64.b64encode(content).decode("utf-8")


### PR DESCRIPTION
## Summary
- fix `FileStore.get_file` to use the configured base directory
- cover bug in a new unit test

## Testing
- `pytest tests/filestore/test_filestore.py::test_get_file -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684c7aa425f48333a42cd4b3f79ee1d9